### PR TITLE
Returns `ReadResult::StreamNotFound` explicitly.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 =====
 * Add DNS record type selection in connection string. DNS A queries are done by default now. Use to be SRV.
 * Export `ConnectionSettingsParseError` type.
+* `read_stream` returns `ReadResult::StreamNotFound` explicitly.
+* Add `Position::end()`
 
 0.9.1
 =====

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Server setup instructions can be found here [EventStoreDB Docs], follow the dock
 # Example
 
 ```rust
-use eventstore::EventStoreDBConnection;
+use eventstore::{ EventData, EventStoreDBConnection, ReadResult };
 use futures::stream::TryStreamExt;
 use serde::{Serialize, Deserialize};
 
@@ -49,18 +49,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .send_event(evt)
         .await?;
 
-    let mut stream = connection
+    let result = connection
         .read_stream("language-stream")
         .start_from_beginning()
         .read_through()
         .await?;
 
-    while let Some(event) = stream.try_next().await? {
-        let event = event.get_original_event()
-                .as_json::<Foo>()?;
-
-        // Do something productive with the result.
-        println!("{:?}", event);
+    if let ReadResult::Ok(mut stream) = result {
+        while let Some(event) = stream.try_next().await? {
+            let event = event.get_original_event()
+                    .as_json::<Foo>()?;
+    
+            // Do something productive with the result.
+            println!("{:?}", event);
+        }
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! # Example
 //!
 //! ```no_run
-//! use eventstore::{ EventStoreDBConnection, EventData };
+//! use eventstore::{ EventStoreDBConnection, EventData, ReadResult };
 //! use futures::stream::TryStreamExt;
 //! use serde::{Serialize, Deserialize};
 //!
@@ -42,18 +42,20 @@
 //!         .send_event(evt)
 //!         .await?;
 //!
-//!     let mut stream = connection
+//!     let result = connection
 //!         .read_stream("language-stream")
 //!         .start_from_beginning()
 //!         .read_through()
 //!         .await?;
 //!
-//!     while let Some(event) = stream.try_next().await? {
-//!         let event = event.get_original_event()
-//!             .as_json::<Foo>()?;
+//!     if let ReadResult::Ok(mut stream) = result {
+//!         while let Some(event) = stream.try_next().await? {
+//!             let event = event.get_original_event()
+//!                     .as_json::<Foo>()?;
 //!
-//!         // Do something productive with the result.
-//!         println!("{:?}", event);
+//!             // Do something productive with the result.
+//!             println!("{:?}", event);
+//!         }
 //!     }
 //!
 //!     Ok(())


### PR DESCRIPTION
Fixes #13 