### PR TITLE
add prelude module and export FilterConf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,14 @@ mod gossip;
 mod grpc_connection;
 mod types;
 
+pub use commands::FilterConf;
 pub use connection::EventStoreDBConnection;
 pub use grpc_connection::{ConnectionSettings, ConnectionSettingsParseError};
 pub use types::*;
+
+pub mod prelude {
+    pub use crate::commands::FilterConf;
+    pub use crate::connection::EventStoreDBConnection;
+    pub use crate::grpc_connection::{ConnectionSettings, ConnectionSettingsParseError};
+    pub use crate::types::*;
+}


### PR DESCRIPTION
This PR is primarily to export FilterConf, as the connection needs the struct in order to call filter, but in the 0.9.x refactor, it is now not publicly accessible.

In that spirit, a a prelude module has also been created.  It is most rust projects like to place commonly used types for the library into a preludes module so that users can import quickly using ```use eventstore::preludes::*;```.

I did ended up duplicating the other ```pub use``` statements in the new preludes in order to not break the API, Documentation, and Tests.  @YoEight would need to decide if this is something you want moving forward, following in the rust ecosystem's footsteps.

