### PR TITLE
Split delete_stream and tombstone_stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub use options::read_stream::*;
 pub use options::retry::*;
 pub use options::subscribe_to_all::*;
 pub use options::subscribe_to_stream::*;
+pub use options::tombstone_stream::*;
 pub use projection_client::*;
 pub use types::*;
 
@@ -104,6 +105,7 @@ pub mod prelude {
     pub use crate::options::retry::*;
     pub use crate::options::subscribe_to_all::*;
     pub use crate::options::subscribe_to_stream::*;
+    pub use crate::options::tombstone_stream::*;
     pub use crate::projection_client::*;
     pub use crate::types::*;
 }

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -8,3 +8,4 @@ pub mod read_stream;
 pub mod retry;
 pub mod subscribe_to_all;
 pub mod subscribe_to_stream;
+pub mod tombstone_stream;

--- a/src/options/tombstone_stream.rs
+++ b/src/options/tombstone_stream.rs
@@ -1,13 +1,13 @@
 use crate::{Credentials, ExpectedRevision};
 
 #[derive(Clone)]
-/// Options of the delete stream command.
-pub struct DeleteStreamOptions {
+/// Options of the tombstone stream command.
+pub struct TombstoneStreamOptions {
     pub(crate) version: ExpectedRevision,
     pub(crate) credentials: Option<Credentials>,
 }
 
-impl Default for DeleteStreamOptions {
+impl Default for TombstoneStreamOptions {
     fn default() -> Self {
         Self {
             version: ExpectedRevision::Any,
@@ -16,7 +16,7 @@ impl Default for DeleteStreamOptions {
     }
 }
 
-impl DeleteStreamOptions {
+impl TombstoneStreamOptions {
     /// Performs the command with the given credentials.
     pub fn authenticated(self, credentials: Credentials) -> Self {
         Self {


### PR DESCRIPTION
Split `delete_stream` into `delete_stream` and `tombstone_stream` rather than using an option.

Related to https://github.com/EventStore/EventStoreDB-Client-Rust/issues/79