### PR TITLE
gRPC disscovery process refactoring.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,10 +50,12 @@ jobs:
           RUST_LOG: integration=debug,eventstore=debug
           RUST_BACKTRACE: 1
 
+      - name: Set up EventStoreDB ${{ matrix.version }} cluster with Docker Compose
+        run: docker-compose up -d
+
       - name: Test on three-cluster-node EventStoreDB ${{ matrix.version }}
         run: |
-          docker-compose up -d
-          cargo test --package eventstore --test integration cluster
+          cargo test --package eventstore --test integration -- cluster
           docker-compose down
         env:
           CONTAINER_IMAGE_VERSION: ${{ matrix.version }}-buster-slim

--- a/src/types.rs
+++ b/src/types.rs
@@ -1251,22 +1251,7 @@ impl NodePreference {
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum Either<A, B> {
-    Left(A),
-    Right(B),
-}
-
-impl<A, B> Either<A, B> {
-    pub(crate) fn as_ref(&self) -> Either<&A, &B> {
-        match self {
-            Either::Left(a) => Either::Left(a),
-            Either::Right(b) => Either::Right(b),
-        }
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct DnsClusterSettings {
     pub(crate) endpoint: Endpoint,
 }


### PR DESCRIPTION
* Reusing the same `tonic::transport::ClientTlsConfig` when creating channels, as creating one is expensive.
* Get rid of unneeded allocations in the connection state-machine code.
* Merge single and cluster mode code together.