### PR TITLE
Refactor operation options internal management.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use crate::{
     GetPersistentSubscriptionInfoOptions, ListPersistentSubscriptionsOptions,
     PersistentSubscription, PersistentSubscriptionInfo, PersistentSubscriptionToAllOptions,
     Position, ReplayParkedMessagesOptions, StreamMetadata, StreamMetadataResult,
-    SubscribeToAllOptions, SubscribeToPersistentSubscriptionn, Subscription, ToCount,
+    SubscribeToAllOptions, SubscribeToPersistentSubscriptionOptions, Subscription, ToCount,
     TombstoneStreamOptions, VersionedMetadata, WriteResult, WrongExpectedVersion,
 };
 use crate::{
@@ -310,7 +310,7 @@ impl Client {
         &self,
         stream_name: impl AsRef<str>,
         group_name: impl AsRef<str>,
-        options: &SubscribeToPersistentSubscriptionn,
+        options: &SubscribeToPersistentSubscriptionOptions,
     ) -> crate::Result<PersistentSubscription> {
         commands::subscribe_to_persistent_subscription(
             &self.client,
@@ -326,7 +326,7 @@ impl Client {
     pub async fn subscribe_to_persistent_subscription_to_all(
         &self,
         group_name: impl AsRef<str>,
-        options: &SubscribeToPersistentSubscriptionn,
+        options: &SubscribeToPersistentSubscriptionOptions,
     ) -> crate::Result<PersistentSubscription> {
         commands::subscribe_to_persistent_subscription(
             &self.client,

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -932,17 +932,16 @@ impl std::fmt::Debug for Msg {
 #[derive(Clone)]
 pub struct GrpcClient {
     pub(crate) sender: futures::channel::mpsc::UnboundedSender<Msg>,
-    default_credentials: Option<Credentials>,
+    connection_settings: ClientSettings,
 }
 
 impl GrpcClient {
-    pub fn create(conn_setts: ClientSettings) -> Self {
-        let default_credentials = conn_setts.default_user_name.clone();
-        let sender = connection_state_machine(conn_setts);
+    pub fn create(connection_settings: ClientSettings) -> Self {
+        let sender = connection_state_machine(connection_settings.clone());
 
         GrpcClient {
             sender,
-            default_credentials,
+            connection_settings,
         }
     }
 
@@ -994,8 +993,8 @@ impl GrpcClient {
         Ok(handle)
     }
 
-    pub fn default_credentials(&self) -> Option<Credentials> {
-        self.default_credentials.clone()
+    pub fn connection_settings(&self) -> &ClientSettings {
+        &self.connection_settings
     }
 }
 

--- a/src/options/append_to_stream.rs
+++ b/src/options/append_to_stream.rs
@@ -1,7 +1,8 @@
 use crate::event_store::client::shared::Empty;
 use crate::event_store::client::streams::append_req::options::ExpectedStreamRevision;
+use crate::options::CommonOperationOptions;
 use crate::private::Sealed;
-use crate::{Credentials, EventData, ExpectedRevision};
+use crate::{impl_options_trait, EventData, ExpectedRevision};
 use futures::future::Ready;
 use futures::stream::{Iter, Once};
 use futures::Stream;
@@ -10,27 +11,21 @@ use futures::Stream;
 /// Options of the append to stream command.
 pub struct AppendToStreamOptions {
     pub(crate) version: ExpectedStreamRevision,
-    pub(crate) credentials: Option<Credentials>,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
 impl Default for AppendToStreamOptions {
     fn default() -> Self {
         Self {
             version: ExpectedStreamRevision::Any(Empty {}),
-            credentials: None,
+            common_operation_options: Default::default(),
         }
     }
 }
 
-impl AppendToStreamOptions {
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, credentials: Credentials) -> Self {
-        Self {
-            credentials: Some(credentials),
-            ..self
-        }
-    }
+impl_options_trait!(AppendToStreamOptions);
 
+impl AppendToStreamOptions {
     /// Asks the server to check that the stream receiving the event is at
     /// the given expected version. Default: `ExpectedVersion::Any`.
     pub fn expected_revision(self, version: ExpectedRevision) -> Self {

--- a/src/options/batch_append.rs
+++ b/src/options/batch_append.rs
@@ -1,15 +1,9 @@
-use crate::Credentials;
+use crate::impl_options_trait;
+use crate::options::CommonOperationOptions;
 
 #[derive(Clone, Default)]
 pub struct BatchAppendOptions {
-    pub(crate) credentials: Option<Credentials>,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
-impl BatchAppendOptions {
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, credentials: Credentials) -> Self {
-        Self {
-            credentials: Some(credentials),
-        }
-    }
-}
+impl_options_trait!(BatchAppendOptions);

--- a/src/options/delete_stream.rs
+++ b/src/options/delete_stream.rs
@@ -1,30 +1,25 @@
-use crate::{Credentials, ExpectedRevision};
+use crate::options::CommonOperationOptions;
+use crate::{impl_options_trait, ExpectedRevision};
 
 #[derive(Clone)]
 /// Options of the delete stream command.
 pub struct DeleteStreamOptions {
     pub(crate) version: ExpectedRevision,
-    pub(crate) credentials: Option<Credentials>,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
 impl Default for DeleteStreamOptions {
     fn default() -> Self {
         Self {
             version: ExpectedRevision::Any,
-            credentials: None,
+            common_operation_options: Default::default(),
         }
     }
 }
 
-impl DeleteStreamOptions {
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, credentials: Credentials) -> Self {
-        Self {
-            credentials: Some(credentials),
-            ..self
-        }
-    }
+impl_options_trait!(DeleteStreamOptions);
 
+impl DeleteStreamOptions {
     /// Asks the server to check that the stream receiving the event is at
     /// the given expected version. Default: `ExpectedVersion::Any`.
     pub fn expected_revision(self, version: ExpectedRevision) -> Self {

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -1,3 +1,7 @@
+use std::time::Duration;
+
+use crate::Credentials;
+
 pub mod append_to_stream;
 pub mod batch_append;
 pub mod delete_stream;
@@ -9,3 +13,55 @@ pub mod retry;
 pub mod subscribe_to_all;
 pub mod subscribe_to_stream;
 pub mod tombstone_stream;
+
+pub(crate) trait Options {
+    fn common_operation_options(&self) -> &CommonOperationOptions;
+}
+
+#[derive(Clone)]
+pub(crate) struct CommonOperationOptions {
+    pub(crate) credentials: Option<Credentials>,
+    pub(crate) requires_leader: bool,
+    pub(crate) deadline: Option<Duration>,
+}
+
+impl Default for CommonOperationOptions {
+    fn default() -> Self {
+        Self {
+            credentials: None,
+            requires_leader: true,
+            deadline: None,
+        }
+    }
+}
+
+// TODO - Use procedural macros instead. It will need a separate crate
+// though.
+#[macro_export]
+macro_rules! impl_options_trait {
+    ($typ:ty) => {
+        impl crate::options::Options for $typ {
+            fn common_operation_options(&self) -> &crate::options::CommonOperationOptions {
+                &self.common_operation_options
+            }
+        }
+
+        impl $typ {
+            /// Performs the command with the given credentials.
+            pub fn authenticated(mut self, credentials: crate::types::Credentials) -> Self {
+                self.common_operation_options.credentials = Some(credentials);
+                self
+            }
+
+            pub fn requires_leader(mut self, requires_leader: bool) -> Self {
+                self.common_operation_options.requires_leader = requires_leader;
+                self
+            }
+
+            pub fn deadline(mut self, deadline: std::time::Duration) -> Self {
+                self.common_operation_options.deadline = Some(deadline);
+                self
+            }
+        }
+    };
+}

--- a/src/options/persistent_subscription.rs
+++ b/src/options/persistent_subscription.rs
@@ -1,24 +1,19 @@
+use crate::options::CommonOperationOptions;
 use crate::{
-    Credentials, PersistentSubscriptionSettings, Position, StreamPosition, SubscriptionFilter,
-    SystemConsumerStrategy,
+    impl_options_trait, Credentials, PersistentSubscriptionSettings, Position, StreamPosition,
+    SubscriptionFilter, SystemConsumerStrategy,
 };
 use std::time::Duration;
 
 #[derive(Clone, Default)]
 pub struct PersistentSubscriptionOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) setts: PersistentSubscriptionSettings<u64>,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
-impl PersistentSubscriptionOptions {
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
-            ..self
-        }
-    }
+impl_options_trait!(PersistentSubscriptionOptions);
 
+impl PersistentSubscriptionOptions {
     /// Applies the specified persistent subscription settings.
     pub fn settings(self, setts: PersistentSubscriptionSettings<u64>) -> Self {
         Self { setts, ..self }
@@ -113,20 +108,14 @@ impl PersistentSubscriptionOptions {
 
 #[derive(Clone, Default)]
 pub struct PersistentSubscriptionToAllOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) setts: PersistentSubscriptionSettings<Position>,
     pub(crate) filter: Option<SubscriptionFilter>,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
-impl PersistentSubscriptionToAllOptions {
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
-            ..self
-        }
-    }
+impl_options_trait!(PersistentSubscriptionToAllOptions);
 
+impl PersistentSubscriptionToAllOptions {
     /// Applies the specified persistent subscription settings.
     pub fn settings(self, setts: PersistentSubscriptionSettings<Position>) -> Self {
         Self { setts, ..self }
@@ -229,42 +218,29 @@ impl PersistentSubscriptionToAllOptions {
 
 #[derive(Clone, Default)]
 pub struct DeletePersistentSubscriptionOptions {
-    pub(crate) credentials: Option<Credentials>,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
-impl DeletePersistentSubscriptionOptions {
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
-        }
-    }
-}
+impl_options_trait!(DeletePersistentSubscriptionOptions);
 
 #[derive(Clone)]
-pub struct SubscribeToPersistentSubscriptionn {
-    pub(crate) credentials: Option<Credentials>,
+pub struct SubscribeToPersistentSubscriptionOptions {
     pub(crate) buffer_size: usize,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
-impl Default for SubscribeToPersistentSubscriptionn {
+impl Default for SubscribeToPersistentSubscriptionOptions {
     fn default() -> Self {
         Self {
-            credentials: None,
             buffer_size: 10,
+            common_operation_options: Default::default(),
         }
     }
 }
 
-impl SubscribeToPersistentSubscriptionn {
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, creds: Credentials) -> Self {
-        Self {
-            credentials: Some(creds),
-            ..self
-        }
-    }
+impl_options_trait!(SubscribeToPersistentSubscriptionOptions);
 
+impl SubscribeToPersistentSubscriptionOptions {
     /// The buffer size to use  for the persistent subscription.
     pub fn buffer_size(self, buffer_size: usize) -> Self {
         Self {

--- a/src/options/projections.rs
+++ b/src/options/projections.rs
@@ -1,22 +1,18 @@
-use crate::types::Credentials;
+use crate::impl_options_trait;
+use crate::options::CommonOperationOptions;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct CreateProjectionOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) track_emitted_streams: bool,
     pub(crate) emit: bool,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
+
+impl_options_trait!(CreateProjectionOptions);
 
 impl CreateProjectionOptions {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
-            ..self
-        }
     }
 
     pub fn track_emitted_streams(self, track_emitted_streams: bool) -> Self {
@@ -31,22 +27,17 @@ impl CreateProjectionOptions {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct UpdateProjectionOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) emit: Option<bool>,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
+
+impl_options_trait!(UpdateProjectionOptions);
 
 impl UpdateProjectionOptions {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
-            ..self
-        }
     }
 
     pub fn emit(self, emit: bool) -> Self {
@@ -57,24 +48,19 @@ impl UpdateProjectionOptions {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct DeleteProjectionOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) delete_emitted_streams: bool,
     pub(crate) delete_state_stream: bool,
     pub(crate) delete_checkpoint_stream: bool,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
+
+impl_options_trait!(DeleteProjectionOptions);
 
 impl DeleteProjectionOptions {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
-            ..self
-        }
     }
 
     pub fn delete_emitted_streams(self, delete_emitted_streams: bool) -> Self {
@@ -99,24 +85,19 @@ impl DeleteProjectionOptions {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct GetStateProjectionOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) partition: String,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
+
+impl_options_trait!(GetStateProjectionOptions);
 
 impl GetStateProjectionOptions {
     pub fn new() -> Self {
         Default::default()
     }
 
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
-            ..self
-        }
-    }
-
     pub fn partition(self, value: impl AsRef<str>) -> Self {
         Self {
             partition: value.as_ref().to_string(),
@@ -125,24 +106,19 @@ impl GetStateProjectionOptions {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct GetResultProjectionOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) partition: String,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
+
+impl_options_trait!(GetResultProjectionOptions);
 
 impl GetResultProjectionOptions {
     pub fn new() -> Self {
         Default::default()
     }
 
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
-            ..self
-        }
-    }
-
     pub fn partition(self, value: impl AsRef<str>) -> Self {
         Self {
             partition: value.as_ref().to_string(),
@@ -150,3 +126,10 @@ impl GetResultProjectionOptions {
         }
     }
 }
+
+#[derive(Clone, Default)]
+pub struct GenericProjectionOptions {
+    pub(crate) common_operation_options: CommonOperationOptions,
+}
+
+impl_options_trait!(GenericProjectionOptions);

--- a/src/options/read_all.rs
+++ b/src/options/read_all.rs
@@ -1,23 +1,26 @@
-use crate::{Credentials, Position, ReadDirection, StreamPosition};
+use crate::options::CommonOperationOptions;
+use crate::{impl_options_trait, Position, ReadDirection, StreamPosition};
 
 #[derive(Clone)]
 pub struct ReadAllOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) direction: ReadDirection,
     pub(crate) position: StreamPosition<Position>,
     pub(crate) resolve_link_tos: bool,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
 impl Default for ReadAllOptions {
     fn default() -> Self {
         Self {
-            credentials: None,
             direction: ReadDirection::Forward,
             position: StreamPosition::Start,
             resolve_link_tos: false,
+            common_operation_options: Default::default(),
         }
     }
 }
+
+impl_options_trait!(ReadAllOptions);
 
 impl ReadAllOptions {
     /// Asks the command to read forward (toward the end of the stream).
@@ -33,14 +36,6 @@ impl ReadAllOptions {
     pub fn backwards(self) -> Self {
         Self {
             direction: ReadDirection::Backward,
-            ..self
-        }
-    }
-
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
             ..self
         }
     }

--- a/src/options/read_stream.rs
+++ b/src/options/read_stream.rs
@@ -1,23 +1,26 @@
-use crate::{Credentials, ReadDirection, StreamPosition};
+use crate::options::CommonOperationOptions;
+use crate::{impl_options_trait, ReadDirection, StreamPosition};
 
 #[derive(Clone)]
 pub struct ReadStreamOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) direction: ReadDirection,
     pub(crate) position: StreamPosition<u64>,
     pub(crate) resolve_link_tos: bool,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
 impl Default for ReadStreamOptions {
     fn default() -> Self {
         Self {
-            credentials: None,
             direction: ReadDirection::Forward,
             position: StreamPosition::Start,
             resolve_link_tos: false,
+            common_operation_options: Default::default(),
         }
     }
 }
+
+impl_options_trait!(ReadStreamOptions);
 
 impl ReadStreamOptions {
     /// Asks the command to read forward (toward the end of the stream).
@@ -33,14 +36,6 @@ impl ReadStreamOptions {
     pub fn backwards(self) -> Self {
         Self {
             direction: ReadDirection::Backward,
-            ..self
-        }
-    }
-
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
             ..self
         }
     }

--- a/src/options/subscribe_to_all.rs
+++ b/src/options/subscribe_to_all.rs
@@ -1,36 +1,31 @@
 use crate::options::retry::RetryOptions;
-use crate::{Credentials, Position, StreamPosition, SubscriptionFilter};
+use crate::options::CommonOperationOptions;
+use crate::{impl_options_trait, Position, StreamPosition, SubscriptionFilter};
 
 #[derive(Clone)]
 pub struct SubscribeToAllOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) position: StreamPosition<Position>,
     pub(crate) resolve_link_tos: bool,
     pub(crate) filter: Option<SubscriptionFilter>,
     pub(crate) retry: Option<RetryOptions>,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
 impl Default for SubscribeToAllOptions {
     fn default() -> Self {
         Self {
             filter: None,
-            credentials: None,
             position: StreamPosition::Start,
             resolve_link_tos: false,
             retry: None,
+            common_operation_options: Default::default(),
         }
     }
 }
 
-impl SubscribeToAllOptions {
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
-            ..self
-        }
-    }
+impl_options_trait!(SubscribeToAllOptions);
 
+impl SubscribeToAllOptions {
     /// Starting point in the transaction journal log. By default, it will start at
     /// `StreamPosition::Start`
     pub fn position(self, position: StreamPosition<Position>) -> Self {

--- a/src/options/subscribe_to_stream.rs
+++ b/src/options/subscribe_to_stream.rs
@@ -1,34 +1,29 @@
 use crate::options::retry::RetryOptions;
-use crate::{Credentials, StreamPosition};
+use crate::options::CommonOperationOptions;
+use crate::{impl_options_trait, StreamPosition};
 
 #[derive(Clone)]
 pub struct SubscribeToStreamOptions {
-    pub(crate) credentials: Option<Credentials>,
     pub(crate) position: StreamPosition<u64>,
     pub(crate) resolve_link_tos: bool,
     pub(crate) retry: Option<RetryOptions>,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
 impl Default for SubscribeToStreamOptions {
     fn default() -> Self {
         Self {
-            credentials: None,
             position: StreamPosition::End,
             resolve_link_tos: false,
             retry: None,
+            common_operation_options: Default::default(),
         }
     }
 }
 
-impl SubscribeToStreamOptions {
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, value: Credentials) -> Self {
-        Self {
-            credentials: Some(value),
-            ..self
-        }
-    }
+impl_options_trait!(SubscribeToStreamOptions);
 
+impl SubscribeToStreamOptions {
     /// For example, if a starting point of 50 is specified when a stream has
     /// 100 events in it, the subscriber can expect to see events 51 through
     /// 100, and then any events subsequently written events until such time

--- a/src/options/tombstone_stream.rs
+++ b/src/options/tombstone_stream.rs
@@ -1,30 +1,25 @@
-use crate::{Credentials, ExpectedRevision};
+use crate::options::CommonOperationOptions;
+use crate::{impl_options_trait, ExpectedRevision};
 
 #[derive(Clone)]
 /// Options of the tombstone stream command.
 pub struct TombstoneStreamOptions {
     pub(crate) version: ExpectedRevision,
-    pub(crate) credentials: Option<Credentials>,
+    pub(crate) common_operation_options: CommonOperationOptions,
 }
 
 impl Default for TombstoneStreamOptions {
     fn default() -> Self {
         Self {
             version: ExpectedRevision::Any,
-            credentials: None,
+            common_operation_options: Default::default(),
         }
     }
 }
 
-impl TombstoneStreamOptions {
-    /// Performs the command with the given credentials.
-    pub fn authenticated(self, credentials: Credentials) -> Self {
-        Self {
-            credentials: Some(credentials),
-            ..self
-        }
-    }
+impl_options_trait!(TombstoneStreamOptions);
 
+impl TombstoneStreamOptions {
     /// Asks the server to check that the stream receiving the event is at
     /// the given expected version. Default: `ExpectedVersion::Any`.
     pub fn expected_revision(self, version: ExpectedRevision) -> Self {


### PR DESCRIPTION
* Expose `deadline` setting for all operation options.
* Expose `requires_leader` setting for all operation options.
* Rewrite how gRPC requests are instantiated.