### PR TITLE
Simplify read_stream and read_all API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ webpki = "0.21"
 base64 = "0.13"
 nom = "7"
 thiserror = "1"
-async-trait = "0.1"
 async-stream = "0.3"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "json"] }
 bitflags = "1.3"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Server setup instructions can be found here [EventStoreDB Docs], follow the dock
 # Example
 
 ```rust
-use eventstore::{ All, Client, EventData, ReadResult };
+use eventstore::{ Client, EventData };
 use serde::{Serialize, Deserialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Creates a client settings for a single node configuration.
     let settings = "esdb://admin:changeit@localhost:2113".parse()?;
-    let client = Client::new(settings).await?;
+    let client = Client::new(settings)?;
 
     let payload = Foo {
         is_rust_a_nice_language: true,
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     let result = client
-        .read_stream("language-stream", &Default::default(), All)
+        .read_stream("language-stream", &Default::default())
         .await?;
 
 	while let Some(event) = stream.next().await? {

--- a/examples/appending_events.rs
+++ b/examples/appending_events.rs
@@ -5,7 +5,7 @@
 
 use eventstore::{
     AppendToStreamOptions, Client, Credentials, EventData, ExpectedRevision, ReadStreamOptions,
-    Single, StreamPosition,
+    StreamPosition,
 };
 use futures::TryStreamExt;
 use serde::{Deserialize, Serialize};
@@ -94,10 +94,11 @@ pub async fn append_with_concurrency_check(client: Client) -> Result<()> {
     let options = ReadStreamOptions::default().position(StreamPosition::End);
 
     let last_event = client
-        .read_stream("concurrency-stream", &options, Single)
+        .read_stream("concurrency-stream", &options)
         .await?
-        .expect("we expect the stream to at least exist.")
-        .expect("we expect the stream to have at least one event.");
+        .next()
+        .await?
+        .expect("the stream to at least exist.");
 
     let data = TestEvent {
         id: "1".to_string(),

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -53,9 +53,8 @@ pub async fn run() -> Result<()> {
     // endregion overriding-user-credentials
 
     // region readStream
-    let mut stream = client
-        .read_stream("some-stream", &Default::default(), 10)
-        .await?;
+    let options = ReadStreamOptions::default().max_count(10);
+    let mut stream = client.read_stream("some-stream", &options).await?;
 
     while let Some(event) = stream.next().await? {
         // Doing something productive with the events.

--- a/examples/reading_events.rs
+++ b/examples/reading_events.rs
@@ -4,8 +4,8 @@
 #![allow(unused_variables)]
 
 use eventstore::{
-    All, Client, Credentials, EventData, ExpectedRevision, Position, ReadAllOptions,
-    ReadStreamOptions, Single, StreamPosition,
+    Client, Credentials, EventData, ExpectedRevision, Position, ReadAllOptions, ReadStreamOptions,
+    StreamPosition,
 };
 use serde::{Deserialize, Serialize};
 use std::error::Error;
@@ -24,7 +24,7 @@ pub async fn read_from_stream(client: &Client) -> Result<()> {
     let options = ReadStreamOptions::default()
         .position(StreamPosition::Start)
         .forwards();
-    let mut stream = client.read_stream("some-stream", &options, All).await?;
+    let mut stream = client.read_stream("some-stream", &options).await?;
     // endregion read-from-stream
 
     // region iterate-stream
@@ -40,8 +40,10 @@ pub async fn read_from_stream(client: &Client) -> Result<()> {
 
 pub async fn read_from_stream_position(client: &Client) -> Result<()> {
     // region read-from-position
-    let options = ReadStreamOptions::default().position(StreamPosition::Position(10));
-    let mut stream = client.read_stream("some-stream", &options, 20).await?;
+    let options = ReadStreamOptions::default()
+        .position(StreamPosition::Position(10))
+        .max_count(20);
+    let mut stream = client.read_stream("some-stream", &options).await?;
     // endregion read-from-position
 
     // region iterate-stream
@@ -61,7 +63,7 @@ pub async fn read_stream_overriding_user_credentials(client: &Client) -> Result<
         .position(StreamPosition::Start)
         .authenticated(Credentials::new("admin", "changeit"));
 
-    let stream = client.read_stream("some-stream", &options, All).await;
+    let stream = client.read_stream("some-stream", &options).await;
     // endregion overriding-user-credentials
     Ok(())
 }
@@ -70,7 +72,7 @@ pub async fn read_from_stream_position_check(client: &Client) -> Result<()> {
     // region checking-for-stream-presence
     let options = ReadStreamOptions::default().position(StreamPosition::Position(10));
 
-    let mut stream = client.read_stream("some-stream", &options, All).await?;
+    let mut stream = client.read_stream("some-stream", &options).await?;
 
     while let Some(event) = stream.next().await? {
         let test_event = event.get_original_event().as_json::<TestEvent>()?;
@@ -86,7 +88,7 @@ pub async fn read_stream_backwards(client: &Client) -> Result<()> {
     let options = ReadStreamOptions::default()
         .position(StreamPosition::End)
         .backwards();
-    let mut stream = client.read_stream("some-stream", &options, All).await?;
+    let mut stream = client.read_stream("some-stream", &options).await?;
 
     while let Some(event) = stream.next().await? {
         let test_event = event.get_original_event().as_json::<TestEvent>()?;
@@ -103,7 +105,7 @@ pub async fn read_from_all_stream(client: &Client) -> Result<()> {
     let options = ReadAllOptions::default()
         .position(StreamPosition::Start)
         .forwards();
-    let mut stream = client.read_all(&Default::default(), All).await?;
+    let mut stream = client.read_all(&Default::default()).await?;
     // endregion read-from-all-stream
 
     // region read-from-all-stream-iterate
@@ -123,7 +125,7 @@ pub async fn read_all_overriding_user_credentials(client: &Client) -> Result<()>
             commit: 1_110,
             prepare: 1_110,
         }));
-    let stream = client.read_all(&options, All).await;
+    let stream = client.read_all(&options).await;
     // endregion read-all-overriding-user-credentials
 
     Ok(())
@@ -131,7 +133,7 @@ pub async fn read_all_overriding_user_credentials(client: &Client) -> Result<()>
 
 pub async fn ignore_system_events(client: &Client) -> Result<()> {
     // region ignore-system-events
-    let mut stream = client.read_all(&Default::default(), All).await?;
+    let mut stream = client.read_all(&Default::default()).await?;
 
     while let Some(event) = stream.next().await? {
         if event.get_original_event().event_type.starts_with("$") {
@@ -149,7 +151,7 @@ pub async fn read_from_all_stream_backwards(client: &Client) -> Result<()> {
     // region read-from-all-stream-backwards
     let options = ReadAllOptions::default().position(StreamPosition::End);
 
-    let mut stream = client.read_all(&options, All).await?;
+    let mut stream = client.read_all(&options).await?;
     // endregion read-from-all-stream-backwards
 
     // region read-from-all-stream-iterate
@@ -162,7 +164,7 @@ pub async fn read_from_all_stream_backwards(client: &Client) -> Result<()> {
 }
 
 pub async fn filtering_out_system_events(client: &Client) -> Result<()> {
-    let mut stream = client.read_all(&Default::default(), All).await?;
+    let mut stream = client.read_all(&Default::default()).await?;
 
     while let Some(event) = stream.next().await? {
         if !event.get_original_event().event_type.starts_with("$") {
@@ -177,7 +179,7 @@ pub async fn filtering_out_system_events(client: &Client) -> Result<()> {
 pub async fn read_from_stream_resolving_link_tos(client: &Client) -> Result<()> {
     // region read-from-all-stream-resolving-link-Tos
     let options = ReadAllOptions::default().resolve_link_tos();
-    client.read_all(&options, All).await?;
+    client.read_all(&options).await?;
     // endregion read-from-all-stream-resolving-link-Tos
     Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,5 @@
 use crate::batch::BatchAppendClient;
+use crate::grpc::{ClientSettings, GrpcClient};
 use crate::options::batch_append::BatchAppendOptions;
 use crate::options::persistent_subscription::PersistentSubscriptionOptions;
 use crate::options::read_all::ReadAllOptions;
@@ -8,13 +9,9 @@ use crate::{
     commands, DeletePersistentSubscriptionOptions, DeleteStreamOptions,
     GetPersistentSubscriptionInfoOptions, ListPersistentSubscriptionsOptions,
     PersistentSubscription, PersistentSubscriptionInfo, PersistentSubscriptionToAllOptions,
-    Position, ReplayParkedMessagesOptions, StreamMetadata, StreamMetadataResult,
-    SubscribeToAllOptions, SubscribeToPersistentSubscriptionOptions, Subscription, ToCount,
+    Position, ReadStream, ReplayParkedMessagesOptions, StreamMetadata, StreamMetadataResult,
+    SubscribeToAllOptions, SubscribeToPersistentSubscriptionOptions, Subscription,
     TombstoneStreamOptions, VersionedMetadata, WriteResult,
-};
-use crate::{
-    grpc::{ClientSettings, GrpcClient},
-    Single,
 };
 use crate::{
     options::append_to_stream::{AppendToStreamOptions, ToEvents},
@@ -88,40 +85,24 @@ impl Client {
 
     /// Reads events from a given stream. The reading can be done forward and
     /// backward.
-    pub async fn read_stream<Count>(
+    pub async fn read_stream(
         &self,
         stream_name: impl AsRef<str>,
         options: &ReadStreamOptions,
-        count: Count,
-    ) -> crate::Result<Count::Selection>
-    where
-        Count: ToCount,
-    {
-        let stream = commands::read_stream(
+    ) -> crate::Result<ReadStream> {
+        commands::read_stream(
             self.client.clone(),
             options,
             stream_name,
-            count.to_count() as u64,
+            options.max_count as u64,
         )
-        .await?;
-
-        Ok(count.select(stream).await)
+        .await
     }
 
     /// Reads events for the system stream `$all`. The reading can be done
     /// forward and backward.
-    pub async fn read_all<Count>(
-        &self,
-        options: &ReadAllOptions,
-        count: Count,
-    ) -> crate::Result<Count::Selection>
-    where
-        Count: ToCount,
-    {
-        let stream =
-            commands::read_all(self.client.clone(), options, count.to_count() as u64).await?;
-
-        Ok(count.select(stream).await)
+    pub async fn read_all(&self, options: &ReadAllOptions) -> crate::Result<ReadStream> {
+        commands::read_all(self.client.clone(), options, options.max_count as u64).await
     }
 
     /// Reads a stream metadata.
@@ -130,11 +111,11 @@ impl Client {
         stream_name: impl AsRef<str>,
         options: &ReadStreamOptions,
     ) -> crate::Result<StreamMetadataResult> {
-        let result = self
-            .read_stream(format!("$${}", stream_name.as_ref()), options, Single)
+        let mut stream = self
+            .read_stream(format!("$${}", stream_name.as_ref()), options)
             .await?;
 
-        match result {
+        match stream.next().await {
             Ok(event) => {
                 let event = event.expect("to be defined");
                 let metadata = event

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,7 @@
 //! # Example
 //!
 //! ```no_run
-//! use eventstore::{ All, Client, EventData, ReadResult };
-//! use futures::stream::TryStreamExt;
+//! use eventstore::{ Client, EventData };
 //! use serde::{Serialize, Deserialize};
 //!
 //! #[derive(Serialize, Deserialize, Debug)]
@@ -25,7 +24,7 @@
 //!
 //!     // Creates a client settings for a single node configuration.
 //!     let settings = "esdb://admin:changeit@localhost:2113".parse()?;
-//!     let client = Client::new(settings).await?;
+//!     let client = Client::new(settings)?;
 //!
 //!     let payload = Foo {
 //!         is_rust_a_nice_language: true,
@@ -39,18 +38,16 @@
 //!         .append_to_stream("language-stream", &Default::default(), evt)
 //!         .await?;
 //!
-//!     let result = client
-//!         .read_stream("language-stream", &Default::default(), All)
+//!     let mut stream = client
+//!         .read_stream("language-stream", &Default::default())
 //!         .await?;
 //!
-//!     if let ReadResult::Ok(mut stream) = result {
-//!         while let Some(event) = stream.try_next().await? {
-//!             let event = event.get_original_event()
-//!                     .as_json::<Foo>()?;
+//!     while let Some(event) = stream.next().await? {
+//!         let event = event.get_original_event()
+//!             .as_json::<Foo>()?;
 //!
-//!             // Do something productive with the result.
-//!             println!("{:?}", event);
-//!         }
+//!         // Do something productive with the result.
+//!         println!("{:?}", event);
 //!     }
 //!
 //!     Ok(())

--- a/src/options/read_all.rs
+++ b/src/options/read_all.rs
@@ -7,6 +7,7 @@ pub struct ReadAllOptions {
     pub(crate) position: StreamPosition<Position>,
     pub(crate) resolve_link_tos: bool,
     pub(crate) common_operation_options: CommonOperationOptions,
+    pub(crate) max_count: usize,
 }
 
 impl Default for ReadAllOptions {
@@ -16,6 +17,7 @@ impl Default for ReadAllOptions {
             position: StreamPosition::Start,
             resolve_link_tos: false,
             common_operation_options: Default::default(),
+            max_count: usize::MAX,
         }
     }
 }
@@ -67,5 +69,9 @@ impl ReadAllOptions {
             resolve_link_tos: true,
             ..self
         }
+    }
+
+    pub fn max_count(self, max_count: usize) -> Self {
+        Self { max_count, ..self }
     }
 }

--- a/src/options/read_stream.rs
+++ b/src/options/read_stream.rs
@@ -7,6 +7,7 @@ pub struct ReadStreamOptions {
     pub(crate) position: StreamPosition<u64>,
     pub(crate) resolve_link_tos: bool,
     pub(crate) common_operation_options: CommonOperationOptions,
+    pub(crate) max_count: usize,
 }
 
 impl Default for ReadStreamOptions {
@@ -16,6 +17,7 @@ impl Default for ReadStreamOptions {
             position: StreamPosition::Start,
             resolve_link_tos: false,
             common_operation_options: Default::default(),
+            max_count: usize::MAX,
         }
     }
 }
@@ -67,5 +69,9 @@ impl ReadStreamOptions {
             resolve_link_tos: true,
             ..self
         }
+    }
+
+    pub fn max_count(self, max_count: usize) -> Self {
+        Self { max_count, ..self }
     }
 }

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,4 +1,4 @@
-use crate::{All, EventData, Single, Streaming};
+use crate::{EventData, Streaming};
 
 pub trait Sealed {}
 
@@ -6,5 +6,3 @@ impl Sealed for usize {}
 impl Sealed for EventData {}
 impl<A: Sealed> Sealed for Vec<A> {}
 impl<I> Sealed for Streaming<I> {}
-impl Sealed for All {}
-impl Sealed for Single {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,8 +6,6 @@ use std::fmt::Formatter;
 use std::time::Duration;
 
 use crate::gossip::VNodeState;
-use crate::private::Sealed;
-use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{de::Visitor, ser::SerializeSeq};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -1422,58 +1420,6 @@ pub enum GrpcConnectionError {
 }
 
 pub type Result<A> = std::result::Result<A, Error>;
-
-#[async_trait]
-pub trait ToCount: Sealed {
-    type Selection;
-    fn to_count(&self) -> usize;
-    async fn select(self, stream: crate::ReadStream) -> Self::Selection;
-}
-
-#[async_trait]
-impl ToCount for usize {
-    type Selection = crate::ReadStream;
-
-    fn to_count(&self) -> usize {
-        *self
-    }
-
-    async fn select(self, stream: crate::ReadStream) -> Self::Selection {
-        stream
-    }
-}
-
-/// Get all the stream's events.
-pub struct All;
-
-#[async_trait]
-impl ToCount for All {
-    type Selection = crate::ReadStream;
-
-    fn to_count(&self) -> usize {
-        usize::MAX
-    }
-
-    async fn select(self, stream: crate::ReadStream) -> Self::Selection {
-        stream
-    }
-}
-
-/// Get only one stream's event.
-pub struct Single;
-
-#[async_trait]
-impl ToCount for Single {
-    type Selection = crate::Result<Option<ResolvedEvent>>;
-
-    fn to_count(&self) -> usize {
-        1
-    }
-
-    async fn select(self, mut stream: crate::ReadStream) -> Self::Selection {
-        stream.next().await
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct SubscriptionFilter {


### PR DESCRIPTION
Changed: Simplify `read_stream` and `read_all` API.

The API is now closer to what other clients are doing.