### PR TITLE
Allow passing an external tokio runtime.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -36,7 +36,15 @@ pub struct Client {
 impl Client {
     /// Creates a gRPC client to an EventStoreDB database.
     pub fn new(settings: ClientSettings) -> crate::Result<Self> {
-        let client = GrpcClient::create(settings.clone());
+        Client::with_runtime_handle(tokio::runtime::Handle::current(), settings)
+    }
+
+    /// Creates a gRPC client to an EventStoreDB database using an existing tokio runtime.
+    pub fn with_runtime_handle(
+        handle: tokio::runtime::Handle,
+        settings: ClientSettings,
+    ) -> crate::Result<Self> {
+        let client = GrpcClient::create(handle, settings.clone());
 
         let http_client = reqwest::Client::builder()
             .danger_accept_invalid_certs(!settings.is_tls_certificate_verification_enabled())

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -809,11 +809,14 @@ impl NodeConnection {
     }
 }
 
-fn connection_state_machine(settings: ClientSettings) -> UnboundedSender<Msg> {
+fn connection_state_machine(
+    handle: tokio::runtime::Handle,
+    settings: ClientSettings,
+) -> UnboundedSender<Msg> {
     let (sender, mut consumer) = futures::channel::mpsc::unbounded::<Msg>();
     let dup_sender = sender.clone();
 
-    tokio::spawn(async move {
+    handle.spawn(async move {
         let mut connection = NodeConnection::new(settings);
         let mut handle_opt: Option<Handle> = None;
 
@@ -971,8 +974,8 @@ pub struct GrpcClient {
 }
 
 impl GrpcClient {
-    pub fn create(connection_settings: ClientSettings) -> Self {
-        let sender = connection_state_machine(connection_settings.clone());
+    pub fn create(handle: tokio::runtime::Handle, connection_settings: ClientSettings) -> Self {
+        let sender = connection_state_machine(handle, connection_settings.clone());
 
         GrpcClient {
             sender,

--- a/src/projection_client.rs
+++ b/src/projection_client.rs
@@ -46,7 +46,11 @@ pub struct ProjectionClient {
 
 impl ProjectionClient {
     pub fn new(settings: ClientSettings) -> Self {
-        let client = GrpcClient::create(settings);
+        ProjectionClient::with_runtime_handle(tokio::runtime::Handle::current(), settings)
+    }
+
+    pub fn with_runtime_handle(handle: tokio::runtime::Handle, settings: ClientSettings) -> Self {
+        let client = GrpcClient::create(handle, settings);
 
         ProjectionClient { client }
     }


### PR DESCRIPTION
Added: Allow passing an external Tokio runtime when creating a new client.

This change facilitates using the Rust client as a static/dynamic library through FFI or using custom tokio runtimes. 