### PR TITLE
Do not apply default deadline on streaming operation.

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -22,7 +22,7 @@ use crate::options::persistent_subscription::PersistentSubscriptionOptions;
 use crate::options::read_all::ReadAllOptions;
 use crate::options::read_stream::ReadStreamOptions;
 use crate::options::subscribe_to_stream::SubscribeToStreamOptions;
-use crate::options::{CommonOperationOptions, Options};
+use crate::options::{CommonOperationOptions, OperationKind, Options};
 use crate::server_features::Features;
 use crate::{
     ClientSettings, CurrentRevision, DeletePersistentSubscriptionOptions, DeleteStreamOptions,
@@ -498,7 +498,9 @@ where
     if let Some(duration) = options.deadline {
         req.set_timeout(duration);
     } else if let Some(duration) = settings.default_deadline {
-        req.set_timeout(duration);
+        if kind != OperationKind::Streaming {
+            req.set_timeout(duration);
+        }
     } else if kind == crate::options::OperationKind::Regular {
         req.set_timeout(Duration::from_secs(10));
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1009,7 +1009,7 @@ async fn wait_for_admin_to_be_available(client: &eventstore::Client) -> eventsto
 #[tokio::test(flavor = "multi_thread")]
 async fn cluster() -> Result<(), Box<dyn std::error::Error>> {
     let _ = pretty_env_logger::try_init();
-    let settings = "esdb://admin:changeit@localhost:2111,localhost:2112,localhost:2113?tlsVerifyCert=false&nodePreference=leader&maxdiscoverattempts=50"
+    let settings = "esdb://admin:changeit@localhost:2111,localhost:2112,localhost:2113?tlsVerifyCert=false&nodePreference=leader&maxdiscoverattempts=50&defaultDeadline=60000"
         .parse::<ClientSettings>()?;
 
     let client = Client::new(settings)?;
@@ -1033,7 +1033,7 @@ async fn single_node() -> Result<(), Box<dyn std::error::Error>> {
     wait_node_is_alive(container.get_host_port(2_113).unwrap()).await?;
 
     let settings = format!(
-        "esdb://localhost:{}?tls=false",
+        "esdb://localhost:{}?tls=false&defaultDeadline=60000",
         container.get_host_port(2_113).unwrap(),
     )
     .parse::<ClientSettings>()?;


### PR DESCRIPTION
Fixed: Do not apply `defaultDeadline` from the connection string on streaming operations.