### PR TITLE
Implement statistics parsing.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -36,6 +36,10 @@ impl Client {
         Client::with_runtime_handle(tokio::runtime::Handle::current(), settings)
     }
 
+    pub fn settings(&self) -> &ClientSettings {
+        self.client.connection_settings()
+    }
+
     /// Creates a gRPC client to an EventStoreDB database using an existing tokio runtime.
     pub fn with_runtime_handle(
         handle: tokio::runtime::Handle,

--- a/src/operations/stats.rs
+++ b/src/operations/stats.rs
@@ -1,0 +1,995 @@
+use crate::event_store::generated::monitoring;
+use crate::grpc::GrpcClient;
+use chrono::{DateTime, Utc};
+use futures::TryStreamExt;
+use std::collections::{BTreeMap, HashMap};
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct StatsOptions {
+    pub(crate) common_operation_options: crate::options::CommonOperationOptions,
+    pub(crate) refresh_time: Duration,
+}
+
+impl Default for StatsOptions {
+    fn default() -> StatsOptions {
+        StatsOptions {
+            common_operation_options: Default::default(),
+            refresh_time: Duration::from_secs(1),
+        }
+    }
+}
+
+impl StatsOptions {
+    pub fn refresh_time(self, value: Duration) -> Self {
+        Self {
+            refresh_time: value,
+            ..self
+        }
+    }
+}
+
+crate::impl_options_trait!(StatsOptions, crate::options::OperationKind::Streaming);
+
+#[derive(Debug, Default, Clone)]
+pub struct Statistics {
+    pub proc: Proc,
+    pub sys: Sys,
+    pub es: Es,
+}
+
+#[derive(Debug, Clone)]
+pub struct Proc {
+    pub id: i64,
+    pub start_time: DateTime<Utc>,
+    pub mem: i64,
+    pub cpu: f64,
+    pub threads_count: i64,
+    pub thrown_exceptions_rate: f64,
+    pub contentions_rate: f64,
+    pub gc: Gc,
+    pub disk_io: DiskIo,
+    pub tcp: Tcp,
+}
+
+impl Default for Proc {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            start_time: std::time::UNIX_EPOCH.into(),
+            mem: 0,
+            cpu: 0.0,
+            threads_count: 0,
+            thrown_exceptions_rate: 0.0,
+            contentions_rate: 0.0,
+            gc: Default::default(),
+            disk_io: Default::default(),
+            tcp: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Gc {
+    pub allocation_speed: f64,
+    pub gen0_items_count: i64,
+    pub gen0_size: i64,
+    pub gen1_items_count: i64,
+    pub gen1_size: i64,
+    pub gen2_items_count: i64,
+    pub gen2_size: i64,
+    pub large_heap_size: i64,
+    pub time_in_gc: f64,
+    pub total_bytes_in_heaps: i64,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Tcp {
+    pub connections: i64,
+    pub receiving_speed: f64,
+    pub sending_speed: f64,
+    pub in_send: i64,
+    pub measure_time: String,
+    pub pending_received: i64,
+    pub pending_send: i64,
+    pub received_bytes_since_last_run: i64,
+    pub received_bytes_total: i64,
+    pub sent_bytes_since_last_run: i64,
+    pub sent_bytes_total: i64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DiskIo {
+    pub read_bytes: i64,
+    pub written_bytes: i64,
+    pub read_ops: i64,
+    pub write_ops: i64,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Sys {
+    pub free_mem: i64,
+    pub loadavg: LoadAvg,
+    pub drive: Option<Drive>,
+}
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct LoadAvg {
+    pub one_m: f64,
+    pub five_m: f64,
+    pub fifteen_m: f64,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Es {
+    pub queues: BTreeMap<String, Queue>,
+    pub checksum: i64,
+    pub checksum_non_flushed: i64,
+    pub writer: Writer,
+    pub read_index: ReadIndex,
+}
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Writer {
+    pub last_flush_size: i64,
+    pub last_flush_delays_ms: f64,
+    pub mean_flush_size: i64,
+    pub mean_flush_delays_ms: f64,
+    pub max_flush_size: i64,
+    pub max_flush_delays_ms: f64,
+    pub queued_flush_messages: i64,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ReadIndex {
+    pub cached_record: i64,
+    pub not_cached_record: i64,
+    pub cached_stream_info: i64,
+    pub not_cached_stream_info: i64,
+    pub cached_trans_info: i64,
+    pub not_cached_trans_info: i64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Queue {
+    pub name: String,
+    pub group_name: String,
+    pub avg_items_per_second: usize,
+    pub current_idle_time: Option<String>,
+    pub current_item_processing_time: Option<String>,
+    pub idle_time_percent: f32,
+    pub length_current_try_peak: i64,
+    pub length_lifetime_peak: i64,
+    pub length: i64,
+    pub avg_processing_time: f64,
+    pub total_items_processed: i64,
+    pub in_progress_message: String,
+    pub last_processed_message: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Drive {
+    pub path: String,
+    pub stats: DriveStats,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DriveStats {
+    pub available_bytes: usize,
+    pub total_bytes: usize,
+    pub usage: String,
+    pub used_bytes: usize,
+}
+
+pub struct Stats {
+    inner: tonic::Streaming<monitoring::StatsResp>,
+}
+
+impl Stats {
+    pub async fn next(&mut self) -> crate::Result<HashMap<String, String>> {
+        let result = self
+            .inner
+            .try_next()
+            .await
+            .map_err(crate::Error::from_grpc)?;
+
+        if let Some(resp) = result {
+            return Ok(resp.stats);
+        }
+
+        Err(crate::Error::ServerError(
+            "Stats stream closes abruptly".to_string(),
+        ))
+    }
+
+    pub async fn next_statistics(&mut self) -> crate::Result<Statistics> {
+        let mut stats = Statistics::default();
+
+        for (key, value) in self.next().await? {
+            match key.as_str() {
+                "proc-startTime" => {
+                    stats.proc.start_time = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-id" => {
+                    stats.proc.id = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-mem" => {
+                    stats.proc.mem = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-cpu" => {
+                    stats.proc.cpu = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-threadsCount" => {
+                    stats.proc.threads_count = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-contentionsRate" => {
+                    stats.proc.contentions_rate = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-thrownExceptionsRate" => {
+                    stats.proc.thrown_exceptions_rate = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-gc-allocationSpeed" => {
+                    stats.proc.gc.allocation_speed = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-gc-gen0ItemsCount" => {
+                    stats.proc.gc.gen0_items_count = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-gc-gen0Size" => {
+                    stats.proc.gc.gen0_size = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-gc-gen1ItemsCount" => {
+                    stats.proc.gc.gen1_items_count = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-gc-gen1Size" => {
+                    stats.proc.gc.gen1_size = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-gc-gen2ItemsCount" => {
+                    stats.proc.gc.gen2_items_count = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-gc-gen2Size" => {
+                    stats.proc.gc.gen2_size = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-gc-largeHeapSize" => {
+                    stats.proc.gc.large_heap_size = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-gc-timeInGc" => {
+                    stats.proc.gc.time_in_gc = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-gc-totalBytesInHeaps" => {
+                    stats.proc.gc.total_bytes_in_heaps = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-diskIo-readBytes" => {
+                    stats.proc.disk_io.read_bytes = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-diskIo-writtenBytes" => {
+                    stats.proc.disk_io.written_bytes = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-diskIo-readOps" => {
+                    stats.proc.disk_io.read_ops = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-diskIo-writeOps" => {
+                    stats.proc.disk_io.write_ops = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-tcp-connections" => {
+                    stats.proc.tcp.connections = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-tcp-receivingSpeed" => {
+                    stats.proc.tcp.receiving_speed = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-tcp-sendingSpeed" => {
+                    stats.proc.tcp.sending_speed = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-tcp-inSend" => {
+                    stats.proc.tcp.in_send = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-tcp-measureTime" => {
+                    stats.proc.tcp.measure_time = value;
+                }
+
+                "proc-tcp-pendingReceived" => {
+                    stats.proc.tcp.pending_received = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-tcp-pendingSend" => {
+                    stats.proc.tcp.pending_send = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-tcp-receivedBytesSinceLastRun" => {
+                    stats.proc.tcp.received_bytes_since_last_run = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-tcp-receivedBytesTotal" => {
+                    stats.proc.tcp.received_bytes_total = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-tcp-sentBytesSinceLastRun" => {
+                    stats.proc.tcp.sent_bytes_since_last_run = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "proc-tcp-sentBytesTotal" => {
+                    stats.proc.tcp.sent_bytes_total = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "sys-loadavg-1m" => {
+                    stats.sys.loadavg.one_m = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "sys-loadavg-5m" => {
+                    stats.sys.loadavg.five_m = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "sys-loadavg-15m" => {
+                    stats.sys.loadavg.fifteen_m = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "sys-freeMem" => {
+                    stats.sys.free_mem = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-checksum" => {
+                    stats.es.checksum = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-checksumNonFlushed" => {
+                    stats.es.checksum_non_flushed = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                key_str if key_str.starts_with("sys-drive-") => {
+                    if stats.sys.drive.is_none() {
+                        let (path, _) = key_str
+                            .strip_prefix("sys-drive-")
+                            .unwrap()
+                            .split_once('-')
+                            .unwrap();
+
+                        stats.sys.drive = Some(Drive {
+                            path: path.to_string(),
+                            stats: Default::default(),
+                        });
+                    }
+
+                    let drive = stats.sys.drive.as_mut().unwrap();
+                    let (_, prop) = key_str.rsplit_once('-').unwrap();
+
+                    match prop {
+                        "availableBytes" => {
+                            drive.stats.available_bytes = value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?;
+                        }
+
+                        "totalBytes" => {
+                            drive.stats.total_bytes = value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?;
+                        }
+
+                        "usage" => {
+                            drive.stats.usage = value;
+                        }
+
+                        "usedBytes" => {
+                            drive.stats.used_bytes = value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?;
+                        }
+
+                        _ => {
+                            warn!("Unknown drive metric: '{}'", prop);
+                        }
+                    }
+                }
+
+                key_str if key_str.starts_with("es-queue-") => {
+                    let (queue_name, prop) = key_str
+                        .strip_prefix("es-queue-")
+                        .unwrap()
+                        .rsplit_once('-')
+                        .unwrap();
+
+                    let queue = stats.es.queues.entry(queue_name.to_string()).or_default();
+
+                    match prop {
+                        "queueName" => {
+                            queue.name = value;
+                        }
+
+                        "groupName" => {
+                            queue.group_name = value;
+                        }
+
+                        "avgItemsPerSecond" => {
+                            queue.avg_items_per_second = value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?;
+                        }
+
+                        "avgProcessingTime" => {
+                            queue.avg_processing_time = value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?;
+                        }
+
+                        "currentIdleTime" => {
+                            if value == "null" {
+                                continue;
+                            }
+
+                            queue.current_idle_time = Some(value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?);
+                        }
+
+                        "currentItemProcessingTime" => {
+                            if value == "null" {
+                                continue;
+                            }
+
+                            queue.current_item_processing_time =
+                                Some(value.parse().map_err(|e| {
+                                    crate::Error::InternalParsingError(format!(
+                                        "{key}: {err} = '{value}'",
+                                        key = key,
+                                        err = e,
+                                        value = value,
+                                    ))
+                                })?);
+                        }
+
+                        "idleTimePercent" => {
+                            queue.idle_time_percent = value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?;
+                        }
+
+                        "length" => {
+                            queue.length = value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?;
+                        }
+
+                        "lengthCurrentTryPeak" => {
+                            queue.length_current_try_peak = value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?;
+                        }
+
+                        "lengthLifetimePeak" => {
+                            queue.length_lifetime_peak = value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?;
+                        }
+
+                        "totalItemsProcessed" => {
+                            queue.total_items_processed = value.parse().map_err(|e| {
+                                crate::Error::InternalParsingError(format!(
+                                    "{key}: {err} = '{value}'",
+                                    key = key,
+                                    err = e,
+                                    value = value,
+                                ))
+                            })?;
+                        }
+
+                        "inProgressMessage" => {
+                            queue.in_progress_message = value;
+                        }
+
+                        "lastProcessedMessage" => {
+                            queue.last_processed_message = value;
+                        }
+
+                        _ => {
+                            warn!("Unknown queue metric: '{}'", key);
+                        }
+                    }
+                }
+
+                "es-writer-lastFlushSize" => {
+                    stats.es.writer.last_flush_size = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-writer-lastFlushDelayMs" => {
+                    stats.es.writer.last_flush_delays_ms = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-writer-meanFlushSize" => {
+                    stats.es.writer.mean_flush_size = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-writer-meanFlushDelayMs" => {
+                    stats.es.writer.mean_flush_delays_ms = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-writer-maxFlushSize" => {
+                    stats.es.writer.max_flush_size = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-writer-maxFlushDelayMs" => {
+                    stats.es.writer.max_flush_delays_ms = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-writer-queuedFlushMessages" => {
+                    stats.es.writer.queued_flush_messages = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-readIndex-cachedRecord" => {
+                    stats.es.read_index.cached_record = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-readIndex-notCachedRecord" => {
+                    stats.es.read_index.not_cached_record = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-readIndex-cachedStreamInfo" => {
+                    stats.es.read_index.cached_stream_info = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-readIndex-notCachedStreamInfo" => {
+                    stats.es.read_index.not_cached_stream_info = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-readIndex-cachedTransInfo" => {
+                    stats.es.read_index.cached_trans_info = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                "es-readIndex-notCachedTransInfo" => {
+                    stats.es.read_index.not_cached_trans_info = value.parse().map_err(|e| {
+                        crate::Error::InternalParsingError(format!(
+                            "{key}: {err} = '{value}'",
+                            key = key,
+                            err = e,
+                            value = value,
+                        ))
+                    })?;
+                }
+
+                _ => {
+                    warn!("Unknown stat metric: '{}'", key);
+                }
+            }
+        }
+
+        Ok(stats)
+    }
+}
+
+pub async fn grpc_stats(client: &GrpcClient, options: &StatsOptions) -> crate::Result<Stats> {
+    let handle = client.current_selected_node().await?;
+
+    let req = monitoring::StatsReq {
+        // Using the metadata messes the parsing for no reason. It only has value in the UI, it's
+        // better to have all the metrics flattened with simple types.
+        use_metadata: false,
+        refresh_time_period_in_ms: options.refresh_time.as_millis() as u64,
+    };
+
+    let req = crate::commands::new_request(client.connection_settings(), options, req);
+    let mut client = monitoring::monitoring_client::MonitoringClient::new(handle.channel);
+
+    let inner = client
+        .stats(req)
+        .await
+        .map_err(crate::Error::from_grpc)?
+        .into_inner();
+
+    Ok(Stats { inner })
+}

--- a/src/projection_client.rs
+++ b/src/projection_client.rs
@@ -55,6 +55,10 @@ impl ProjectionClient {
         ProjectionClient { client }
     }
 
+    pub fn settings(&self) -> &ClientSettings {
+        self.client.connection_settings()
+    }
+
     pub async fn create<Name>(
         &self,
         name: Name,
@@ -596,4 +600,10 @@ fn parse_value(value: prost_types::Value) -> serde_json::Value {
     }
 
     param.expect("not empty")
+}
+
+impl From<crate::Client> for ProjectionClient {
+    fn from(src: crate::Client) -> Self {
+        Self { client: src.client }
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1283,18 +1283,12 @@ async fn test_gossip(client: &operations::Client) -> eventstore::Result<()> {
 }
 
 async fn test_stats(client: &operations::Client) -> eventstore::Result<()> {
-    let options = StatsOptions::default()
-        .use_metadata(true)
-        .refresh_time(Duration::from_millis(500));
+    let options = StatsOptions::default().refresh_time(Duration::from_millis(500));
 
     let mut stream = client.stats(&options).await?;
-    let result = stream.next().await?;
+    let result = stream.next_statistics().await?;
 
-    assert!(result.is_some());
-
-    let result = result.unwrap();
-
-    assert!(result.len() > 0);
+    assert!(result.es.queues.len() > 0);
     Ok(())
 }
 


### PR DESCRIPTION
Added: Implement statistics parsing.
Removed: Remove `use_metadata` option when reading stats.

By implementing statistics parsing, we make the statistics object
easier to use. Note that it's still possible to access the raw
representation if needed.

I removed `use_metadata` option because when turned on, many metrics are no longer flattened properly when using the gRPC endpoint. Metrics like `proc-cpu` or `proc-freeMem` had `EventStore.Core.Services.Monitoring.Stats.StatMetadata` as value.