### PR TITLE
Fix RequiresLeader header when node preference is set to leader.

### DIFF
--- a/eventstore/src/commands.rs
+++ b/eventstore/src/commands.rs
@@ -30,8 +30,8 @@ use crate::server_features::Features;
 use crate::{
     ClientSettings, CurrentRevision, DeletePersistentSubscriptionOptions, DeleteStreamOptions,
     GetPersistentSubscriptionInfoOptions, ListPersistentSubscriptionsOptions, NakAction,
-    PersistentSubscriptionConnectionInfo, PersistentSubscriptionEvent, PersistentSubscriptionInfo,
-    PersistentSubscriptionMeasurements, PersistentSubscriptionStats,
+    NodePreference, PersistentSubscriptionConnectionInfo, PersistentSubscriptionEvent,
+    PersistentSubscriptionInfo, PersistentSubscriptionMeasurements, PersistentSubscriptionStats,
     PersistentSubscriptionToAllOptions, ReplayParkedMessagesOptions,
     RestartPersistentSubscriptionSubsystem, RetryOptions, RevisionOrPosition,
     SubscribeToAllOptions, SubscribeToPersistentSubscriptionOptions, SubscriptionFilter,
@@ -500,7 +500,7 @@ where
         metadata.insert("authorization", header_value);
     }
 
-    if options.requires_leader {
+    if options.requires_leader || settings.node_preference() == NodePreference::Leader {
         let header_value = MetadataValue::from_str("true").expect("valid metadata header value");
         metadata.insert("requires-leader", header_value);
     }

--- a/eventstore/src/options/mod.rs
+++ b/eventstore/src/options/mod.rs
@@ -19,21 +19,11 @@ pub(crate) trait Options {
     fn kind(&self) -> OperationKind;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) struct CommonOperationOptions {
     pub(crate) credentials: Option<Credentials>,
     pub(crate) requires_leader: bool,
     pub(crate) deadline: Option<Duration>,
-}
-
-impl Default for CommonOperationOptions {
-    fn default() -> Self {
-        Self {
-            credentials: None,
-            requires_leader: true,
-            deadline: None,
-        }
-    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Fixed: Fix `RequiresLeader` header when node preference is set to leader.