### PR TITLE
Fix bug in version check

### DIFF
--- a/eventstore/tests/integration.rs
+++ b/eventstore/tests/integration.rs
@@ -1641,7 +1641,8 @@ async fn all_around_tests(
     let is_at_least_22;
 
     if let Some(info) = op_client.server_version().await? {
-        is_at_least_21_10 = info.version().major() >= 21 && info.version().minor() >= 10;
+        is_at_least_21_10 = info.version().major() == 21 && info.version().minor() >= 10
+            || info.version().major() > 21;
         is_at_least_22 = info.version().major() >= 22;
     } else {
         // older versions did not have the server version api


### PR DESCRIPTION
Fixed: Bug in version check in tests

Example: 22.6 would previously fail the `is_at_least_21_10` check