### PR TITLE
remove default-features for the crate 'chrono'

### DIFF
--- a/eventstore-extras/Cargo.toml
+++ b/eventstore-extras/Cargo.toml
@@ -15,5 +15,5 @@ categories = ["database", "api-bindings"]
 [dependencies]
 # will move to version number once we got something stable.
 eventstore = { path = "../eventstore", version = "2.2.0" }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 log = "0.4"

--- a/eventstore/Cargo.toml
+++ b/eventstore/Cargo.toml
@@ -23,7 +23,7 @@ base64 = "0.13"
 bitflags = "1"
 byteorder = "1.2"
 bytes = "1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
 eventstore-macros = { path = "../eventstore-macros", version = "0.0.1" }
 futures = "0.3"
 http = "0.2"


### PR DESCRIPTION
Fixed: No longer transitively depend on `time` 0.1 

Hi,

`eventstore` is depending on `chrono` with default features enabled, which transitively depends on the crate `time 0.1` 
that has a known vulnerability: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26235

But, as far as I can see, `eventstore` does not need the `oldtime` feature enabled by default by chrono, and could therefore remove the transitive dependency on the vulnerable crate `time 0.1` by disabling the default features of chrono.
