### PR TITLE
DEV-283 - Fix parsing of server semver for CI

### DIFF
--- a/eventstore/src/server_features.rs
+++ b/eventstore/src/server_features.rs
@@ -143,9 +143,14 @@ pub(crate) async fn supported_methods(
         .into_inner();
 
     let mut version = ServerVersion::default();
+    let semver: String = methods
+        .event_store_server_version
+        .chars()
+        .filter(|&c| c.is_ascii_digit() || c == '.')
+        .collect();
 
     // Server version uses sem versioning.
-    for (idx, ver) in methods.event_store_server_version.split('.').enumerate() {
+    for (idx, ver) in semver.split('.').enumerate() {
         if idx > 2 {
             break;
         }


### PR DESCRIPTION
Fixed: parsing of server semver for CI, where the server version may have tagging