### PR TITLE
DEV-45-6 - Pull es-gencert-cli from Cloudsmith

### DIFF
--- a/configure-tls-for-tests.yml
+++ b/configure-tls-for-tests.yml
@@ -10,7 +10,7 @@ services:
     network_mode: "none"
 
   setup:
-    image: eventstore/es-gencert-cli:1.0.2
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
     entrypoint: bash
     user: "1000:1000"
     command: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     network_mode: none
 
   cert-gen:
-    image: eventstore/es-gencert-cli:1.0.2
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
     entrypoint: bash
     user: "1000:1000"
     command: >


### PR DESCRIPTION
Changed: Updated everywhere to pull es-gencert-cli from Cloudsmith