### PR TITLE
[DEVEX-223] Add support for changing the root certificate

### DIFF
--- a/eventstore/src/grpc.rs
+++ b/eventstore/src/grpc.rs
@@ -840,7 +840,8 @@ impl NodeConnection {
                 roots.add(cert).unwrap();
             }
         } else {
-            for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs")
+            for cert in
+                rustls_native_certs::load_native_certs().expect("could not load platform certs")
             {
                 roots.add(cert).unwrap();
             }

--- a/eventstore/tests/fixtures/connection_string/mockups.toml
+++ b/eventstore/tests/fixtures/connection_string/mockups.toml
@@ -428,3 +428,20 @@ user_key_file = "bar"
 host = "localhost"
 port = 2_113
 
+[[mockups]]
+string = "esdb://localhost?tlsCaFile=foo"
+[mockups.expected]
+dns_discover = false
+max_discover_attempts = 3
+discovery_interval = 500
+gossip_timeout = 3_000
+preference = "Leader"
+secure = true
+tls_verify_cert = true
+tls_ca_file = "foo"
+keep_alive_interval = 10_000
+keep_alive_timeout = 10_000
+[[mockups.expected.hosts]]
+host = "localhost"
+port = 2_113
+

--- a/eventstore/tests/integration.rs
+++ b/eventstore/tests/integration.rs
@@ -2,6 +2,7 @@ mod api;
 mod common;
 mod images;
 mod plugins;
+mod misc;
 
 use crate::common::{fresh_stream_id, generate_events};
 use eventstore::{Client, ClientSettings};
@@ -160,6 +161,7 @@ async fn wait_for_admin_to_be_available(client: &Client) -> eventstore::Result<(
 enum Tests {
     Api(ApiTests),
     Plugins(PluginTests),
+    Misc(MiscTests)
 }
 
 impl Tests {
@@ -189,6 +191,14 @@ impl From<PluginTests> for Tests {
     fn from(test: PluginTests) -> Self {
         Tests::Plugins(test)
     }
+}
+
+enum MiscTests {
+    RootCertificates,
+}
+
+impl From<MiscTests> for Tests {
+    fn from(test: MiscTests) -> Self { Tests::Misc(test) }
 }
 
 enum Topologies {
@@ -266,6 +276,10 @@ async fn run_test(test: impl Into<Tests>, topology: Topologies) -> eyre::Result<
                 plugins::user_certificates::tests(container_port).await
             }
         },
+
+        Tests::Misc(test) => match test {
+            MiscTests::RootCertificates => misc::root_certificates::tests(container_port).await
+        },
     };
 
     result?;
@@ -295,6 +309,11 @@ async fn single_node_operations() -> eyre::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn plugin_usercertificates() -> eyre::Result<()> {
     run_test(PluginTests::UserCertificates, Topologies::SingleNode).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn root_certificates() -> eyre::Result<()> {
+    run_test(MiscTests::RootCertificates, Topologies::SingleNode).await
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/eventstore/tests/integration.rs
+++ b/eventstore/tests/integration.rs
@@ -1,8 +1,8 @@
 mod api;
 mod common;
 mod images;
-mod plugins;
 mod misc;
+mod plugins;
 
 use crate::common::{fresh_stream_id, generate_events};
 use eventstore::{Client, ClientSettings};
@@ -161,7 +161,7 @@ async fn wait_for_admin_to_be_available(client: &Client) -> eventstore::Result<(
 enum Tests {
     Api(ApiTests),
     Plugins(PluginTests),
-    Misc(MiscTests)
+    Misc(MiscTests),
 }
 
 impl Tests {
@@ -198,7 +198,9 @@ enum MiscTests {
 }
 
 impl From<MiscTests> for Tests {
-    fn from(test: MiscTests) -> Self { Tests::Misc(test) }
+    fn from(test: MiscTests) -> Self {
+        Tests::Misc(test)
+    }
 }
 
 enum Topologies {
@@ -278,7 +280,7 @@ async fn run_test(test: impl Into<Tests>, topology: Topologies) -> eyre::Result<
         },
 
         Tests::Misc(test) => match test {
-            MiscTests::RootCertificates => misc::root_certificates::tests(container_port).await
+            MiscTests::RootCertificates => misc::root_certificates::tests(container_port).await,
         },
     };
 

--- a/eventstore/tests/misc/mod.rs
+++ b/eventstore/tests/misc/mod.rs
@@ -1,0 +1,1 @@
+pub mod root_certificates;

--- a/eventstore/tests/misc/root_certificates.rs
+++ b/eventstore/tests/misc/root_certificates.rs
@@ -1,10 +1,11 @@
-pub async fn tests(port: u16) -> eyre::Result<()> {
+use tracing::debug;
+
+async fn test_with_valid_root_certificate(port: u16) -> eyre::Result<()> {
     let root_cert = "certs/ca/ca.crt";
 
     let setts = format!(
         "esdb://admin:changeit@localhost:{}?tlsVerifyCert=true&tls=true&tlsCaFile={}",
-        port,
-        root_cert
+        port, root_cert
     )
     .parse()?;
     let client = eventstore::Client::new(setts)?;
@@ -12,6 +13,39 @@ pub async fn tests(port: u16) -> eyre::Result<()> {
     let mut streams = client.read_all(&Default::default()).await?;
 
     streams.next().await?;
+
+    Ok(())
+}
+
+async fn test_with_invalid_certificate(port: u16) -> eyre::Result<()> {
+    // invalid root certificate
+    let root_cert = "certs/node1/node.crt";
+
+    let setts = format!(
+        "esdb://admin:changeit@localhost:{}?tlsVerifyCert=true&tls=true&tlsCaFile={}",
+        port, root_cert
+    )
+    .parse()?;
+    let client = eventstore::Client::new(setts)?;
+
+    let result = client.read_all(&Default::default()).await;
+
+    assert!(
+        result.is_err(),
+        "Expected an error due to invalid certificate"
+    );
+
+    Ok(())
+}
+
+pub async fn tests(port: u16) -> eyre::Result<()> {
+    debug!("Before test_with_valid_root_certificate…");
+    test_with_valid_root_certificate(port).await?;
+    debug!("Complete");
+
+    debug!("Before test_with_invalid_certificate…");
+    test_with_invalid_certificate(port).await?;
+    debug!("Complete");
 
     Ok(())
 }

--- a/eventstore/tests/misc/root_certificates.rs
+++ b/eventstore/tests/misc/root_certificates.rs
@@ -1,0 +1,17 @@
+pub async fn tests(port: u16) -> eyre::Result<()> {
+    let root_cert = "certs/ca/ca.crt";
+
+    let setts = format!(
+        "esdb://admin:changeit@localhost:{}?tlsVerifyCert=true&tls=true&tlsCaFile={}",
+        port,
+        root_cert
+    )
+    .parse()?;
+    let client = eventstore::Client::new(setts)?;
+
+    let mut streams = client.read_all(&Default::default()).await?;
+
+    streams.next().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces support for specifying a custom TLS CA file in the `eventstore` crate. It includes changes to the `ClientSettings` struct, updates to the connection parsing logic, and new tests to validate the functionality.

Key changes:

### TLS CA File Support:

* [`eventstore/src/grpc.rs`](diffhunk://#diff-5d537c5af2422f7e6f1ffc7f5036a9cc69b831844ac5152233290241cd762b2fR364): Added `tls_ca_file` field to `ClientSettings` struct and updated related methods to handle this new field. This includes adding a getter method and updating the `parse_from_url` function to parse the `tlsCaFile` parameter from the connection string. 
* [`eventstore/src/grpc.rs`](diffhunk://#diff-5d537c5af2422f7e6f1ffc7f5036a9cc69b831844ac5152233290241cd762b2fL815-R849): Modified `NodeConnection::new` to load the custom TLS CA file if provided, otherwise, it falls back to loading the platform certificates.
