### PR TITLE
docs: Fix Java reference in Getting Started

### DIFF
--- a/docs/api/getting-started.md
+++ b/docs/api/getting-started.md
@@ -4,7 +4,7 @@ order: 1
 
 # Getting started
 
-This guide will help you get started with KurrentDB in your Java application.
+This guide will help you get started with KurrentDB in your Rust application.
 It covers the basic steps to connect to KurrentDB, create events, append them
 to streams, and read them back.
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Update Getting Started guide language reference from Java to Rust


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Getting Started Guide"] -- "Update language reference" --> B["Java → Rust"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getting-started.md</strong><dd><code>Update language reference from Java to Rust</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/api/getting-started.md

<ul><li>Changed introductory text from "Java application" to "Rust <br>application"<br> <li> Corrects the language context for the Getting Started guide</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB-Client-Rust/pull/222/files#diff-f0b89dd533c0839cf8821dc492c16fcc3a12b97a6d2ee74340585a7acedb8aea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

